### PR TITLE
Add quantized-mesh-encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ https://github.com/AnalyticalGraphicsInc/quantized-mesh
 
 - https://github.com/kjartab/qmesh - qmesh (Javascript)
 
-- https://github.com/heremaps//quantized-mesh-decoder - decoder for the Quantized Mesh format (Javascript)
+- https://github.com/heremaps/quantized-mesh-decoder - decoder for the Quantized Mesh format (Javascript)
 
+- https://github.com/kylebarron/quantized-mesh-encoder - fast Quantized Mesh encoder (Python)
 
 ## Tile generators
 


### PR DESCRIPTION
Add link to `quantized-mesh-encoder` for fast Python Quantized Mesh encoding.

I also ported a fast square heightmap to mesh generator to Python, but not sure if that belongs on the README. https://github.com/kylebarron/pymartini